### PR TITLE
Fix square hitbox and manage images click=close

### DIFF
--- a/modules/gui.py
+++ b/modules/gui.py
@@ -2429,7 +2429,7 @@ class MainGUI():
                 imgui.push_style_var(imgui.STYLE_ITEM_SPACING, (spacing, spacing))
                 for idx, image in enumerate(game.additional_images):
                     x1, y1 = imgui.get_cursor_pos()
-                    imgui.selectable(f"##image_dummy{image.resolved_path.name}", width=image_width, height=image_height)
+                    imgui.invisible_button(f"##image_dummy{image.resolved_path.name}", image_width, image_height)
                     if imgui.begin_drag_drop_source(flags=dnd_flags):
                         payload = idx + 1
                         payload = payload.to_bytes(payload.bit_length(), sys.byteorder)


### PR DESCRIPTION
Clicking images in the manage images popup would dismiss and bring back the popup, causing flicker. Also the hitbox did not respect rounded corner settings (due to how imgui selectables work) and imo also looked off. `imgui.invisible_button()` can act as a hitbox while also having an id, and has the added benefit of not closing the popup. Alternatively, could add `flags=imgui.SELECTABLE_DONT_CLOSE_POPUPS` to the selectable instead, but I think this is better.

Also, I pushed to F95Checker with constant height for banner images, which solves another gripe I had with your wonderful carousel system where changing image would shift the carousel up and down due to different image sizes. Tried applying to my local clone and it works great! I'll leave merging that properly to you tho

I'll play around more with your fork and let you know more of what I think but it's looking great so far! Definitely wanna merge some of this great stuff